### PR TITLE
Allow boolean attributes to be set with actual booleans

### DIFF
--- a/src/Attribute.php
+++ b/src/Attribute.php
@@ -13,7 +13,7 @@ class Attribute implements Renderable
     /** @var string */
     protected $name;
 
-    /** @var string|null */
+    /** @var string|bool */
     protected $value;
 
     /**
@@ -25,7 +25,7 @@ class Attribute implements Renderable
     public function __construct (string $tag, string $name, $value = true)
     {
         $this->setName($tag, $name);
-        $this->setValue($value);
+        $this->value = $value;
     }
 
     /**
@@ -60,17 +60,6 @@ class Attribute implements Renderable
     }
 
     /**
-     * @param string|bool $value
-     * @return $this
-     */
-    public function setValue ($value)
-    {
-        $this->value = $value;
-
-        return $this;
-    }
-
-    /**
      * @return string|bool
      */
     public function getValue ()
@@ -84,7 +73,11 @@ class Attribute implements Renderable
      */
     public function render () : string
     {
-        return is_bool($this->value)
+        if ($this->value === false) {
+            return '';
+        }
+
+        return $this->value === true
             ? $this->name
             : $this->name . '="' . $this->value . '"';
     }

--- a/src/Bags/AbstractBag.php
+++ b/src/Bags/AbstractBag.php
@@ -79,7 +79,7 @@ abstract class AbstractBag implements Renderable, Bag
      */
     public function render () : string
     {
-        return '' . array_reduce($this->items, [$this, 'reduceCallback']);
+        return '' . array_reduce($this->items, [$this, 'reduceCb']);
     }
 
     /**
@@ -93,5 +93,5 @@ abstract class AbstractBag implements Renderable, Bag
      * @param $item
      * @return mixed
      */
-    abstract public function reduceCallback($carry, Renderable $item);
+    abstract public function reduceCb($carry, Renderable $item);
 }

--- a/src/Bags/ClassBag.php
+++ b/src/Bags/ClassBag.php
@@ -46,7 +46,7 @@ class ClassBag extends AbstractBag
     public function render () : string
     {
         return $this->hasItems()
-            ? 'class="' . trim(array_reduce($this->items, [$this, 'reduceCallback'])) . '"'
+            ? 'class="' . trim(array_reduce($this->items, [$this, 'reduceCb'])) . '"'
             : '';
     }
 
@@ -55,7 +55,7 @@ class ClassBag extends AbstractBag
      * @param \Aviator\Html\Interfaces\Renderable $renderable
      * @return string
      */
-    public function reduceCallback ($carry, Renderable $renderable)
+    public function reduceCb ($carry, Renderable $renderable)
     {
         $carry .= $renderable->getName() . ' ';
         return $carry;

--- a/src/Bags/ContentBag.php
+++ b/src/Bags/ContentBag.php
@@ -36,7 +36,7 @@ class ContentBag extends AbstractBag
      * @param \Aviator\Html\Interfaces\Renderable $renderable
      * @return string
      */
-    public function reduceCallback ($carry, Renderable $renderable)
+    public function reduceCb ($carry, Renderable $renderable)
     {
         $carry .= $renderable->render();
         return $carry;

--- a/tests/AttributeBagTest.php
+++ b/tests/AttributeBagTest.php
@@ -45,10 +45,34 @@ class AttributeBagTest extends TestCase
     }
 
     /** @test */
+    public function setting_a_boolean_attribute_with_value_true ()
+    {
+        $bag = new AttributeBag('input', ['disabled' => true]);
+
+        $this->assertSame('disabled', $bag->render());
+    }
+
+    /** @test */
+    public function setting_a_boolean_attribute_with_value_false ()
+    {
+        $bag = new AttributeBag('input', ['disabled' => false]);
+
+        $this->assertSame('', $bag->render());
+    }
+
+    /** @test */
     public function rendering_the_bag ()
     {
-        $bag = AttributeBag::make('input', ['name' => 'test', 'id' => 'test2']);
+        $bag = new AttributeBag('input', [
+            'name' => 'test',
+            'id' => 'test2',
+            'disabled' => false,
+            'autofocus' => true,
+        ]);
 
-        $this->assertSame('name="test" id="test2"', $bag->render());
+        $this->assertSame(
+            'name="test" id="test2" autofocus',
+            $bag->render()
+        );
     }
 }


### PR DESCRIPTION
Previously `new Tag('input', [], ['disabled' => 'false']` would render `<input disabled>`. This has been fixed.